### PR TITLE
use native hkdf

### DIFF
--- a/lib/web_push.rb
+++ b/lib/web_push.rb
@@ -2,7 +2,6 @@
 
 require 'openssl'
 require 'base64'
-require 'hkdf'
 require 'jwt'
 require 'uri'
 require 'net/http'

--- a/lib/web_push/encryption.rb
+++ b/lib/web_push/encryption.rb
@@ -8,6 +8,7 @@ module WebPush
       assert_arguments(message, p256dh, auth)
 
       group_name = 'prime256v1'
+      hash = 'SHA256'
       salt = Random.new.bytes(16)
 
       server = OpenSSL::PKey::EC.generate(group_name)
@@ -25,11 +26,11 @@ module WebPush
       content_encryption_key_info = "Content-Encoding: aes128gcm\0"
       nonce_info = "Content-Encoding: nonce\0"
 
-      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).read(32)
+      prk = OpenSSL::KDF.hkdf(shared_secret, salt: client_auth_token, info: info, hash: hash, length: 32)
 
-      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).read(16)
+      content_encryption_key = OpenSSL::KDF.hkdf(prk, salt: salt, info: content_encryption_key_info, hash: hash, length: 16)
 
-      nonce = HKDF.new(prk, salt: salt, info: nonce_info).read(12)
+      nonce = OpenSSL::KDF.hkdf(prk, salt: salt, info: nonce_info, hash: hash, length: 12)
 
       ciphertext = encrypt_payload(message, content_encryption_key, nonce)
 

--- a/spec/web_push/encryption_spec.rb
+++ b/spec/web_push/encryption_spec.rb
@@ -65,10 +65,10 @@ describe WebPush::Encryption do
       content_encryption_key_info = "Content-Encoding: aes128gcm\0"
       nonce_info = "Content-Encoding: nonce\0"
 
-      prk = HKDF.new(shared_secret, salt: client_auth_token, algorithm: 'SHA256', info: info).read(32)
+      prk = OpenSSL::KDF.hkdf(shared_secret, salt: client_auth_token, info: info, hash: 'SHA256', length: 32)
 
-      content_encryption_key = HKDF.new(prk, salt: salt, info: content_encryption_key_info).read(16)
-      nonce = HKDF.new(prk, salt: salt, info: nonce_info).read(12)
+      content_encryption_key = OpenSSL::KDF.hkdf(prk, salt: salt, info: content_encryption_key_info, hash: 'SHA256', length: 16)
+      nonce = OpenSSL::KDF.hkdf(prk, salt: salt, info: nonce_info, hash: 'SHA256', length: 12)
 
       decrypt_ciphertext(ciphertext, content_encryption_key, nonce)
     end

--- a/web-push.gemspec
+++ b/web-push.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'hkdf', '~> 1.0'
   spec.add_dependency 'jwt', '~> 2.0'
   spec.add_dependency 'openssl', '~> 3.0'
 


### PR DESCRIPTION
`OpenSSL::KDF.hkdf` has been around since ruby 2.5

```ruby
require 'benchmark'
require 'openssl'
require 'hkdf'

salt = Random.new.bytes(16)
shared_secret = Random.new.bytes(32)
info = 'helloworld'

Benchmark.bm do |benchmark|
  n = 50_000
  benchmark.report('gem') do
    n.times do
      HKDF.new(shared_secret, salt: salt, algorithm: 'SHA256', info: info).next_bytes(32)
    end
  end
  benchmark.report('native') do
    n.times do
      OpenSSL::KDF.hkdf(shared_secret, salt: salt, info: info, hash: 'SHA256', length: 32)
    end
  end
end
```