### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Ruby 3.3 is now available. This PR adds Ruby 3.3 to the CI matrix.

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/