### PR TITLE
Set openssl 3.2

### DIFF
--- a/lib/web_push/version.rb
+++ b/lib/web_push/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebPush
-  VERSION = '3.0.1'.freeze
+  VERSION = '3.0.2'.freeze
 end

--- a/web-push.gemspec
+++ b/web-push.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'jwt', '~> 2.0'
-  spec.add_dependency 'openssl', '~> 3.0'
+  spec.add_dependency 'openssl', '~> 3.2'
 
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.0'


### PR DESCRIPTION
This PR sets openssl version to 3.2 at least

Issue related: https://github.com/pushpad/web-push/issues/12