### PR TITLE
Introduce UnknownError

### DIFF
--- a/lib/web_push/errors.rb
+++ b/lib/web_push/errors.rb
@@ -26,4 +26,6 @@ module WebPush
   class TooManyRequests < ResponseError; end
 
   class PushServiceError < ResponseError; end
+
+  class UnknownError < ResponseError; end
 end

--- a/lib/web_push/request.rb
+++ b/lib/web_push/request.rb
@@ -154,7 +154,7 @@ module WebPush
       elsif resp.is_a?(Net::HTTPServerError) # 5xx
         raise PushServiceError.new(resp, uri.host)
       elsif !resp.is_a?(Net::HTTPSuccess) # unknown/unhandled response error
-        raise ResponseError.new(resp, uri.host)
+        raise UnknownError.new(resp, uri.host)
       end
     end
   end


### PR DESCRIPTION
Hello!

Rather than raising `ResponseError`, which is also used as a base class for other errors, we now raise `UnknownError`.

This results in more specific error reporting when an unknown error occurs. For example, you can now handle unknown errors separately to `ResponseError` exceptions.

Compatibility:

Because `UnknownError` is still a subclass of `ResponseError`, if you are currently rescuing `ResponseError` or using `Object#is_a?`, your code will still work. If you're checking against the specific constant you will need to update your code.

## Why?

If you're handling errors from the library by rescuing them like this:

```ruby
begin
  WebPush.payload_send(…)
rescue WebPush::InvalidSubscription, WebPush::ExpiredSubscription
  # Handle invalid subscriptions in some way (we mark them as deleted)
rescue WebPush::ResponseError => e
  # Handle all known response errors in the same way.
  #
  # This will also catch "unknown errors" which aren't expected by the library.
rescue Errno::ECONNRESET, Net::OpenTimeout, OpenSSL::SSL::SSLError
  # Handle connection errors
end
```

Because the unknown error is just a `WebPush::ResponseError` it's more difficult to handle it differently without explicitly rescuing all the other kinds of `WebPush::ResponseError` earlier. With this change you can rescue `WebPush::UnknownError` before the generic `WebPush::ResponseError` and handle it separately. Unknown errors can be important to look at separately rather then rescuing them along with all the other known errors.

Cheers