### PR TITLE
add new EdgeThrottled exception

### DIFF
--- a/lib/web_push/errors.rb
+++ b/lib/web_push/errors.rb
@@ -26,4 +26,6 @@ module WebPush
   class TooManyRequests < ResponseError; end
 
   class PushServiceError < ResponseError; end
+
+  class EdgeThrottled < ResponseError; end
 end

--- a/lib/web_push/request.rb
+++ b/lib/web_push/request.rb
@@ -147,6 +147,8 @@ module WebPush
       elsif resp.is_a?(Net::HTTPUnauthorized) || resp.is_a?(Net::HTTPForbidden) || # 401, 403
             resp.is_a?(Net::HTTPBadRequest) && resp.message == 'UnauthorizedRegistration' # 400, Google FCM
         raise Unauthorized.new(resp, uri.host)
+      elsif resp.is_a?(Net::HTTPNotAcceptable) && uri.host.to_s.ends_with?("notify.windows.com") #406 on Edge
+        raise EdgeThrottled.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPRequestEntityTooLarge) # 413
         raise PayloadTooLarge.new(resp, uri.host)
       elsif resp.is_a?(Net::HTTPTooManyRequests) # 429, try again later!


### PR DESCRIPTION
Edge throttles *much* more aggressively than other browsers, so I added a new ResponseError subclass called EdgeThrottled and added code to verify_response to distinguish this case from a generic ResponseError. I'd still like to know if I ever get throttled by Chrome, Firefox, or Safari since it's never happened before, but it happens so much with Edge that I've just given up and ignore these exceptions personally. Others may want to handle this specific case differently as well.

If this PR would be accepted, let me know and I'll write some tests for it