### PR TITLE
Relax dependnecy on JWT

### DIFF
--- a/web-push.gemspec
+++ b/web-push.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'jwt', '~> 3.0'
+  spec.add_dependency 'jwt', '>= 2', '< 4'
   spec.add_dependency 'openssl', '>= 3.0'
 
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
`jwt` is a very popular depdency, and numerous other gems are yet to be updated to allow `jwt 3.x`.

Since `web-push` works fine with `jwt 2.x`, I see no reason to prevent installation.